### PR TITLE
feat: support webpack4

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function SshWebpackPlugin(options) {
 
 SshWebpackPlugin.prototype.apply = function (compiler) {
     var that = this;
-    compiler.plugin('done',function (compilation) {
+    compiler.hooks.emit.tap('done',function (compilation) {
         that.deploy();
     });
 }


### PR DESCRIPTION
fix: `compiler.plugin is not a function` in webpack5.

Refs: [webpack4 hooks](https://webpack.js.org/api/compiler-hooks/#emit)